### PR TITLE
fix: add types marker file

### DIFF
--- a/codeforlife/py.typed
+++ b/codeforlife/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561. The codeforlife package uses inline types.


### PR DESCRIPTION
This fix add the types marker file for PEP 561. This informs static type checkers like mypy that the codeforlife package supports type hints. We are using inline type hints there's no need to specify anything in the marker file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-package-python/23)
<!-- Reviewable:end -->
